### PR TITLE
Fix unneeded character escapes

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -19,4 +19,4 @@ targets:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.10.0
+    version: ~> 0.11.0

--- a/spec/converters/yaml_spec.cr
+++ b/spec/converters/yaml_spec.cr
@@ -239,7 +239,7 @@ describe OQ::Converters::Yaml do
       pending "with a complex sequence key" do
         it "should output correctly" do
           run_binary(COMPLEX_SEQUENCE_KEY, args: ["-i", "yaml", "-c", "."]) do |output|
-            output.should eq %({"[\"Manchester United\", \"Real Madrid\"]":["2001-01-01T00:00:00Z","2002-02-02T00:00:00Z"]}\n)
+            output.should eq %({"["Manchester United", "Real Madrid"]":["2001-01-01T00:00:00Z","2002-02-02T00:00:00Z"]}\n)
           end
         end
       end

--- a/spec/oq_spec.cr
+++ b/spec/oq_spec.cr
@@ -42,7 +42,7 @@ describe OQ do
   describe "with the -C option" do
     it "should colorize the output" do
       run_binary(input: SIMPLE_JSON_OBJECT, args: [".", "-c", "-C"]) do |output|
-        output.should eq %(\e[1;39m{\e[0m\e[34;1m\"name\"\e[0m\e[1;39m:\e[0m\e[0;32m\"Jim\"\e[0m\e[1;39m\e[1;39m}\e[0m\n)
+        output.should eq %(\e[1;39m{\e[0m\e[34;1m"name"\e[0m\e[1;39m:\e[0m\e[0;32m"Jim"\e[0m\e[1;39m\e[1;39m}\e[0m\n)
       end
     end
   end


### PR DESCRIPTION
Crystal Nightly on CI failed due to upcoming syntax/formatter changes.

* Bump ameba version