### PR TITLE
Argv parsing refactor

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,7 +16,7 @@ jobs:
       run: apk add --update --upgrade --no-cache --force-overwrite libxml2-dev yaml-dev
     - name: Build
       run: |
-        shards build --production --static --no-debug --link-flags "$(pkg-config libxml-2.0 --libs --static)"
+        shards build --production --release --static --no-debug --link-flags "$(pkg-config libxml-2.0 --libs --static)"
         strip ./bin/oq
     - name: Upload
       uses: actions/upload-release-asset@v1.0.1

--- a/spec/oq_spec.cr
+++ b/spec/oq_spec.cr
@@ -63,26 +63,34 @@ describe OQ do
     end
   end
 
-  describe "with a file input" do
-    it "should return the correct output" do
-      run_binary(input: "", args: [".", "spec/assets/data1.json"]) do |output|
-        output.should eq "#{SIMPLE_JSON_OBJECT}\n"
+  describe "files" do
+    describe "with a file input" do
+      it "should return the correct output" do
+        run_binary(input: "", args: [".", "---", "spec/assets/data1.json"]) do |output|
+          output.should eq "#{SIMPLE_JSON_OBJECT}\n"
+        end
       end
     end
-  end
 
-  describe "with multiple JSON file input" do
-    it "should return the correct output" do
-      run_binary(input: "", args: ["-c", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
-        output.should eq %({"name":"Jim"}\n{"name":"Bob"}\n)
+    describe "with multiple JSON file input" do
+      it "should return the correct output" do
+        run_binary(input: "", args: ["-c", ".", "---", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
+          output.should eq %({"name":"Jim"}\n{"name":"Bob"}\n)
+        end
       end
     end
-  end
 
-  describe "with multiple JSON file input and slurp" do
-    it "should return the correct output" do
-      run_binary(input: "", args: ["-c", "--slurp", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
-        output.should eq %([{"name":"Jim"},{"name":"Bob"}]\n)
+    describe "with multiple JSON file input and slurp" do
+      it "should return the correct output" do
+        run_binary(input: "", args: ["-c", "--slurp", ".", "---", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
+          output.should eq %([{"name":"Jim"},{"name":"Bob"}]\n)
+        end
+      end
+    end
+
+    it "with multiple --arg" do
+      run_binary(input: "", args: ["-c", "-r", "--arg", "chart", "stolon", "--arg", "version", "1.5.10", "$version", "---", "spec/assets/data1.json"]) do |output|
+        output.should eq %(1.5.10\n)
       end
     end
   end
@@ -176,10 +184,22 @@ describe OQ do
     end
   end
 
-  describe "with the --arg option" do
-    it "should be passed correctly" do
+  describe "--arg" do
+    it "single arg" do
       run_binary(input: %({}), args: ["-c", "--arg", "foo", "bar", %({"name":$foo})]) do |output|
         output.should eq %({"name":"bar"}\n)
+      end
+    end
+
+    it "multiple arg" do
+      run_binary(input: %("a: b"), args: ["-c", "-r", "--arg", "chart", "stolon", "--arg", "version", "1.5.10", "$version"]) do |output|
+        output.should eq %(1.5.10\n)
+      end
+    end
+
+    it "different option in between args" do
+      run_binary(input: %("a: b"), args: ["-c", "--arg", "chart", "stolon", "-r", "--arg", "version", "1.5.10", "$version"]) do |output|
+        output.should eq %(1.5.10\n)
       end
     end
   end

--- a/spec/oq_spec.cr
+++ b/spec/oq_spec.cr
@@ -66,7 +66,7 @@ describe OQ do
   describe "files" do
     describe "with a file input" do
       it "should return the correct output" do
-        run_binary(input: "", args: [".", "spec/assets/data1.json"]) do |output|
+        run_binary(args: [".", "spec/assets/data1.json"]) do |output|
           output.should eq "#{SIMPLE_JSON_OBJECT}\n"
         end
       end
@@ -74,7 +74,7 @@ describe OQ do
 
     describe "with multiple JSON file input" do
       it "should return the correct output" do
-        run_binary(input: "", args: ["-c", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
+        run_binary(args: ["-c", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
           output.should eq %({"name":"Jim"}\n{"name":"Bob"}\n)
         end
       end
@@ -82,14 +82,14 @@ describe OQ do
 
     describe "with multiple JSON file input and slurp" do
       it "should return the correct output" do
-        run_binary(input: "", args: ["-c", "--slurp", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
+        run_binary(args: ["-c", "--slurp", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
           output.should eq %([{"name":"Jim"},{"name":"Bob"}]\n)
         end
       end
     end
 
     it "with multiple --arg" do
-      run_binary(input: "", args: ["-c", "-r", "--arg", "chart", "stolon", "--arg", "version", "1.5.10", "$version", "spec/assets/data1.json"]) do |output|
+      run_binary(args: ["-c", "-r", "--arg", "chart", "stolon", "--arg", "version", "1.5.10", "$version", "spec/assets/data1.json"]) do |output|
         output.should eq %(1.5.10\n)
       end
     end

--- a/spec/oq_spec.cr
+++ b/spec/oq_spec.cr
@@ -41,7 +41,7 @@ describe OQ do
 
   describe "with the -C option" do
     it "should colorize the output" do
-      run_binary(input: SIMPLE_JSON_OBJECT, args: [".", "-c", "-C"]) do |output|
+      run_binary(input: SIMPLE_JSON_OBJECT, args: ["-c", "-C", "."]) do |output|
         output.should eq %(\e[1;39m{\e[0m\e[34;1m"name"\e[0m\e[1;39m:\e[0m\e[0;32m"Jim"\e[0m\e[1;39m\e[1;39m}\e[0m\n)
       end
     end
@@ -49,14 +49,14 @@ describe OQ do
 
   describe "with a non-JSON output format" do
     it "should convert the JSON to that format" do
-      run_binary(input: SIMPLE_JSON_OBJECT, args: [".", "-o", "yaml"]) do |output|
+      run_binary(input: SIMPLE_JSON_OBJECT, args: ["-o", "yaml", "."]) do |output|
         output.should eq "---\nname: Jim\n"
       end
     end
 
     describe "with the -C option" do
       it "should remove the -C option" do
-        run_binary(input: SIMPLE_JSON_OBJECT, args: [".", "-o", "yaml", "-C"]) do |output|
+        run_binary(input: SIMPLE_JSON_OBJECT, args: ["-o", "yaml", "-C", "."]) do |output|
           output.should eq "---\nname: Jim\n"
         end
       end
@@ -66,7 +66,7 @@ describe OQ do
   describe "files" do
     describe "with a file input" do
       it "should return the correct output" do
-        run_binary(input: "", args: [".", "---", "spec/assets/data1.json"]) do |output|
+        run_binary(input: "", args: [".", "spec/assets/data1.json"]) do |output|
           output.should eq "#{SIMPLE_JSON_OBJECT}\n"
         end
       end
@@ -74,7 +74,7 @@ describe OQ do
 
     describe "with multiple JSON file input" do
       it "should return the correct output" do
-        run_binary(input: "", args: ["-c", ".", "---", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
+        run_binary(input: "", args: ["-c", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
           output.should eq %({"name":"Jim"}\n{"name":"Bob"}\n)
         end
       end
@@ -82,14 +82,14 @@ describe OQ do
 
     describe "with multiple JSON file input and slurp" do
       it "should return the correct output" do
-        run_binary(input: "", args: ["-c", "--slurp", ".", "---", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
+        run_binary(input: "", args: ["-c", "--slurp", ".", "spec/assets/data1.json", "spec/assets/data2.json"]) do |output|
           output.should eq %([{"name":"Jim"},{"name":"Bob"}]\n)
         end
       end
     end
 
     it "with multiple --arg" do
-      run_binary(input: "", args: ["-c", "-r", "--arg", "chart", "stolon", "--arg", "version", "1.5.10", "$version", "---", "spec/assets/data1.json"]) do |output|
+      run_binary(input: "", args: ["-c", "-r", "--arg", "chart", "stolon", "--arg", "version", "1.5.10", "$version", "spec/assets/data1.json"]) do |output|
         output.should eq %(1.5.10\n)
       end
     end
@@ -170,7 +170,7 @@ describe OQ do
 
   describe "when using 'input'" do
     it "should return the correct output" do
-      run_binary(args: ["-cnf", "spec/assets/stream-filter", "spec/assets/stream-data.json"]) do |output|
+      run_binary(args: ["-c", "-n", "-f", "spec/assets/stream-filter", "spec/assets/stream-data.json"]) do |output|
         output.should eq %({"possible_victim01":{"total":3,"evildoers":{"evil.com":2,"soevil.com":1}},"possible_victim02":{"total":1,"evildoers":{"bad.com":1}},"possible_victim03":{"total":1,"evildoers":{"soevil.com":1}}}\n)
       end
     end

--- a/src/oq.cr
+++ b/src/oq.cr
@@ -34,55 +34,41 @@ module OQ
   end
 
   struct Processor
-    private FILE_SEPARATOR = "---"
-
     # The format that the input data is in.
-    property input_format : Format = Format::Json
+    setter input_format : Format = Format::Json
 
     # The format that the output should be transcoded into.
-    property output_format : Format = Format::Json
+    setter output_format : Format = Format::Json
 
     # The args passed to the program.
     #
     # Non `oq` args are passed to `jq`.
-    property args : Array(String) = [] of String
+    getter args : Array(String) = [] of String
 
     # The root of the XML document when transcoding to XML.
-    property xml_root : String = "root"
+    setter xml_root : String = "root"
 
     # If the XML prolog should be emitted.
-    property xml_prolog : Bool = true
+    setter xml_prolog : Bool = true
 
     # The name for XML array elements without keys.
-    property xml_item : String = "item"
+    setter xml_item : String = "item"
 
     # The number of spaces to use for indentation.
-    property indent : Int32 = 2
+    setter indent : Int32 = 2
 
-    # :nodoc:
-    property tab : Bool = false
+    # If a tab for each indentation level instead of two spaces.
+    setter tab : Bool = false
 
     # Consume the input, convert the input to JSON if needed, pass the input/args to `jq`, then convert the output if needed.
     def process : Nil
-      # Gather the args to pass to jq
-      @args.concat ARGV.take_while &.!=(FILE_SEPARATOR)
+      # Parse out --rawfile, --argfile, --slurpfile, and -f/--from-file before processing additional args
+      # since these options use a file that should not be used as input
+      self.consume_file_args "--rawfile", "--argfile", "--slurpfile"
+      self.consume_file_args "-f", "--from-file", count: 1
 
-      # Remove the file separator
-      ARGV.delete FILE_SEPARATOR
-
-      # Remove the extracted args from ARGV leaving only the files
-      ARGV.replace ARGV - @args
-
-      # Add color option if STDOUT is a tty
-      # and the output format is JSON
-      # (Since it will go straight to STDOUT and not converted)
-      @args.unshift "-C" if STDOUT.tty? && output_format.json?
-
-      # If the -C option was explicitly included
-      # and the output format is not JSON;
-      # remove it from the args to prevent
-      # conversion errors
-      @args.delete("-C") if !output_format.json?
+      # Extract `jq` arguments from `ARGV`
+      self.extract_args
 
       input_read, input_write = IO.pipe
       output_read, output_write = IO.pipe
@@ -90,7 +76,7 @@ module OQ
       channel = Channel(Bool).new
 
       spawn do
-        input_format.converter.deserialize(ARGF, input_write)
+        @input_format.converter.deserialize(ARGF, input_write)
         input_write.close
         channel.send true
       rescue ex
@@ -99,13 +85,13 @@ module OQ
 
       spawn do
         output_write.close
-        output_format.converter.serialize(
+        @output_format.converter.serialize(
           output_read,
           STDOUT,
-          indent: ((tab ? "\t" : " ")*indent),
-          xml_root: xml_root,
-          xml_prolog: xml_prolog,
-          xml_item: xml_item
+          indent: ((@tab ? "\t" : " ")*@indent),
+          xml_root: @xml_root,
+          xml_prolog: @xml_prolog,
+          xml_item: @xml_item
         )
         channel.send true
       rescue ex
@@ -131,6 +117,41 @@ module OQ
 
     private def handle_error(ex : Exception)
       abort "oq error: #{ex.message}"
+    end
+
+    # Parses `ARGV`, extracting `jq` arguments while leaving files
+    private def extract_args : Nil
+      # Add color option if STDOUT is a tty
+      # and the output format is JSON
+      # (Since it will go straight to STDOUT and not converted)
+      ARGV.unshift "-C" if STDOUT.tty? && @output_format.json? && !ARGV.includes? "-C"
+
+      # If the -C option was explicitly included
+      # and the output format is not JSON;
+      # remove it from the args to prevent
+      # conversion errors
+      ARGV.delete("-C") if !@output_format.json?
+
+      # If there are any files within ARGV, ignore "." as it's both a valid file and filter
+      idx = if first_file_idx = ARGV.index { |arg| arg != "." && File.exists? arg }
+              # extract everything else
+              first_file_idx - 1
+            else
+              # otherwise just take it all
+              -1
+            end
+
+      @args.concat ARGV.delete_at 0..idx
+    end
+
+    # Extracts the provided *arg_name* from `ARGV` if it exists;
+    # concatenating the result to the internal arg array.
+    private def consume_file_arg(arg_name : String, count : Int32 = 2) : Nil
+      ARGV.index(arg_name).try { |idx| @args.concat ARGV.delete_at idx..(idx + count) }
+    end
+
+    private def consume_file_args(*arg_names : String, count : Int32 = 2) : Nil
+      arg_names.each { |name| consume_file_arg name, count }
     end
   end
 end

--- a/src/oq_cli.cr
+++ b/src/oq_cli.cr
@@ -27,7 +27,7 @@ module OQ
     end
     parser.on("-i FORMAT", "--input FORMAT", "Format of the input data. Supported formats: #{Format}") { |format| (f = Format.parse?(format)) ? processor.input_format = f : abort "Invalid input format: '#{format}'" }
     parser.on("-o FORMAT", "--output FORMAT", "Format of the output data. Supported formats: #{Format}") { |format| (f = Format.parse?(format)) ? processor.output_format = f : abort "Invalid output format: '#{format}'" }
-    parser.on("--indent NUMBER", "Use the given number of spaces for indentation (JSON/XML only).") { |n| processor.args.push "--indent", n.to_i }
+    parser.on("--indent NUMBER", "Use the given number of spaces for indentation (JSON/XML only).") { |n| processor.indent = n.to_i; processor.args << "--indent"; processor.args << n }
     parser.on("--xml-root ROOT", "Name of the root XML element if converting to XML.") { |r| processor.xml_root = r }
     parser.on("--no-prolog", "Whether the XML prolog should be emitted if converting to XML.") { processor.xml_prolog = false }
     parser.on("--xml-item NAME", "The name for XML array elements without keys.") { |i| processor.xml_item = i }

--- a/src/oq_cli.cr
+++ b/src/oq_cli.cr
@@ -3,16 +3,10 @@ require "option_parser"
 require "./oq"
 
 module OQ
-  private def self.consume_arguments(flag : String, positions : Int32? = 1) : Array
-    idx = ARGV.index(flag).not_nil!
-    positions = positions ? positions : ARGV[idx..].size
-    ARGV.delete_at idx..(idx + positions)
-  end
-
   processor = Processor.new
 
   OptionParser.parse do |parser|
-    parser.banner = "Usage: oq [--help] [oq-arguments] [jq-arguments] jq_filter [file [files...]]"
+    parser.banner = "Usage: oq [--help] [oq-arguments] [jq-arguments] jq_filter --- [file [files...]]"
     parser.on("-h", "--help", "Show this help message.") do
       output = IO::Memory.new
       version = IO::Memory.new
@@ -37,17 +31,8 @@ module OQ
     parser.on("--xml-root ROOT", "Name of the root XML element if converting to XML.") { |r| processor.xml_root = r }
     parser.on("--no-prolog", "Whether the XML prolog should be emitted if converting to XML.") { processor.xml_prolog = false }
     parser.on("--xml-item NAME", "The name for XML array elements without keys.") { |i| processor.xml_item = i }
-    parser.invalid_option do |flag|
-      case flag
-      when "--tab"                                          then processor.tab = true
-      when "-L"                                             then processor.args.concat consume_arguments flag; next
-      when "--arg", "--argjson", "--slurpfile", "--rawfile" then processor.args.concat consume_arguments flag, 2; next
-      when "--args", "--jsonargs"                           then processor.args.concat consume_arguments flag, nil; next
-      else
-      end
-
-      processor.args << flag
-    end
+    parser.on("--tab", "Use a tab for each indentation level instead of two spaces.") { processor.tab = true; processor.args << "--tab" }
+    parser.invalid_option { }
   end
 
   processor.process

--- a/src/oq_cli.cr
+++ b/src/oq_cli.cr
@@ -27,7 +27,7 @@ module OQ
     end
     parser.on("-i FORMAT", "--input FORMAT", "Format of the input data. Supported formats: #{Format}") { |format| (f = Format.parse?(format)) ? processor.input_format = f : abort "Invalid input format: '#{format}'" }
     parser.on("-o FORMAT", "--output FORMAT", "Format of the output data. Supported formats: #{Format}") { |format| (f = Format.parse?(format)) ? processor.output_format = f : abort "Invalid output format: '#{format}'" }
-    parser.on("--indent NUMBER", "Use the given number of spaces for indentation (JSON/XML only).") { |n| processor.indent = n.to_i; processor.args << "--indent"; processor.args << n }
+    parser.on("--indent NUMBER", "Use the given number of spaces for indentation (JSON/XML only).") { |n| processor.args.push "--indent", n.to_i }
     parser.on("--xml-root ROOT", "Name of the root XML element if converting to XML.") { |r| processor.xml_root = r }
     parser.on("--no-prolog", "Whether the XML prolog should be emitted if converting to XML.") { processor.xml_prolog = false }
     parser.on("--xml-item NAME", "The name for XML array elements without keys.") { |i| processor.xml_item = i }

--- a/src/oq_cli.cr
+++ b/src/oq_cli.cr
@@ -6,7 +6,7 @@ module OQ
   processor = Processor.new
 
   OptionParser.parse do |parser|
-    parser.banner = "Usage: oq [--help] [oq-arguments] [jq-arguments] jq_filter --- [file [files...]]"
+    parser.banner = "Usage: oq [--help] [oq-arguments] [jq-arguments] jq_filter [file [files...]]"
     parser.on("-h", "--help", "Show this help message.") do
       output = IO::Memory.new
       version = IO::Memory.new


### PR DESCRIPTION
Refactors `ARGV` processing in order to be more robust.  Better handles multiple arguments and files.  Retains BC but is slightly more strict in the order arguments are passed.  Follow the usage instructions.

Fixes #57 