### PR TITLE
Fix now invalid variable name

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,10 +3,10 @@ require "../src/oq"
 
 # Runs the the binary with the given *name* and *args*.
 def run_binary(input : String? = nil, name : String = "bin/oq", args : Array(String) = [] of String, &block : String, Process::Status, String -> Nil)
-  buffer = IO::Memory.new
-  error = IO::Memory.new
-  in = IO::Memory.new
-  in << input if input
-  status = Process.run(name, args, output: buffer, input: in.rewind, error: error)
-  yield buffer.to_s, status, error.to_s
+  buffer_io = IO::Memory.new
+  error_io = IO::Memory.new
+  input_io = IO::Memory.new
+  input_io << input if input
+  status = Process.run(name, args, output: buffer_io, input: input_io.rewind, error: error_io)
+  yield buffer_io.to_s, status, error_io.to_s
 end


### PR DESCRIPTION
Spotted in nightly CI: https://github.com/Blacksmoke16/oq/runs/668590723?check_suite_focus=true

https://github.com/crystal-lang/crystal/pull/9258 made the `in` variable name invalid.