### PR TITLE
0.35.0 Updates

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,7 +16,7 @@ jobs:
       run: apk add --update --upgrade --no-cache --force-overwrite libxml2-dev yaml-dev
     - name: Build
       run: |
-        shards build --production --release --static --no-debug --link-flags "$(pkg-config libxml-2.0 --libs --static)"
+        shards build --production --release --static --no-debug
         strip ./bin/oq
     - name: Upload
       uses: actions/upload-release-asset@v1.0.1

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ version: 1.1.0
 authors:
   - George Dietrich <george@dietrich.app>
 
-crystal: 0.31.0
+crystal: 0.35.0
 
 license: MIT
 

--- a/spec/format_spec.cr
+++ b/spec/format_spec.cr
@@ -1,0 +1,9 @@
+require "./spec_helper"
+
+describe OQ::Format do
+  describe ".to_s" do
+    it "returns a comma separated list of the formats" do
+      OQ::Format.to_s.should eq "json, yaml, xml"
+    end
+  end
+end

--- a/src/oq.cr
+++ b/src/oq.cr
@@ -16,7 +16,7 @@ module OQ
 
     # Returns the list of supported formats.
     def self.to_s(io : IO) : Nil
-      self.names.join(io, ", ") { |str, io| str.downcase io }
+      self.names.join(io, ", ") { |str, join_io| str.downcase join_io }
     end
 
     # Maps a given format to its converter.

--- a/src/oq.cr
+++ b/src/oq.cr
@@ -15,8 +15,8 @@ module OQ
     Xml
 
     # Returns the list of supported formats.
-    def self.to_s : String
-      names.map(&.downcase).join(", ")
+    def self.to_s(io : IO) : Nil
+      self.names.join(io, ", ") { |str, io| str.downcase io }
     end
 
     # Maps a given format to its converter.
@@ -24,10 +24,8 @@ module OQ
       {% begin %}
         case self
           {% for format in @type.constants %}
-            when .{{format.downcase.id}}? then OQ::Converters::{{format.id}}
+            in .{{format.downcase.id}}? then OQ::Converters::{{format.id}}
           {% end %}
-        else
-          raise "Unsupported format: '#{self}'."
         end
       {% end %}
     end


### PR DESCRIPTION
Fixes the supported formats in the help info:
```
-i FORMAT, --input FORMAT        Format of the input data. Supported formats: OQ::Format
-o FORMAT, --output FORMAT       Format of the output data. Supported formats: OQ::Format
```

Now correctly lists the supported formats.

NOTE: Requires crystal `0.35.0`