### PR TITLE
Allow snap to access home and USB drives

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,9 @@ base: core18
 apps:
   oq:
     command: bin/oq
+    plugs:
+      - home
+      - removable-media
 
 parts:
   oq:


### PR DESCRIPTION
Currently, the snap binary cannot access the home folder and plugged in USB drives...this pull request adds the support by declaring necessary snap plugs.