### PR TITLE
Add `SimpleYAML` input format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A performant, portable [jq](https://github.com/stedolan/jq/) wrapper thats facil
 
 * Compiles to a single binary for easy portability.
 * Performant, similar performance with JSON data compared to `jq`.  Slightly longer execution time when going to/from a non-JSON format.  
-* Supports XML and YAML as additional input/output formats.
+* Supports various other input/output [formats](https://blacksmoke16.github.io/oq/OQ/Format.html), such as `XML` and `YAML`.
 * Can be used as a dependency within other Crystal projects.
 
 ## Installation

--- a/spec/converters/simple_yaml_spec.cr
+++ b/spec/converters/simple_yaml_spec.cr
@@ -1,0 +1,366 @@
+require "../spec_helper"
+
+# Essentially copied from the `YAML` spec, minus the `with anchors` test.
+#
+# TODO: Allow the test code to be more easily shared.
+describe OQ::Converters::SimpleYAML do
+  describe ".deserialize" do
+    describe String do
+      describe "not blank" do
+        it "should output correctly" do
+          run_binary(%(--- Jim), args: ["-i", "simpleyaml", "."]) do |output|
+            output.should eq %("Jim"\n)
+          end
+        end
+      end
+
+      describe "blank" do
+        it "should output correctly" do
+          run_binary(%(--- ), args: ["-i", "simpleyaml", "."]) do |output|
+            output.should eq "null\n"
+          end
+        end
+      end
+
+      describe "with a tag" do
+        it "should output correctly" do
+          run_binary(%(--- !!str 0.5), args: ["-i", "simpleyaml", "."]) do |output|
+            output.should eq %("0.5"\n)
+          end
+        end
+      end
+
+      describe "that is single quoted" do
+        it "should output correctly" do
+          run_binary(%(---\nhowever: 'foobar'), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"however":"foobar"}\n)
+          end
+        end
+      end
+
+      describe "that is double quoted" do
+        it "should output correctly" do
+          run_binary(%(---\nhowever: "foobar"), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"however":"foobar"}\n)
+          end
+        end
+      end
+
+      describe "literal block" do
+        it "should output correctly" do
+          run_binary(LITERAL_BLOCK, args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"literal_block":"This entire block of text will be the value of the 'literal_block' key,\\nwith line breaks being preserved.\\n\\nThe literal continues until de-dented, and the leading indentation is\\nstripped.\\n\\n    Any lines that are 'more-indented' keep the rest of their indentation -\\n    these lines will be indented by 4 spaces."}\n)
+          end
+        end
+      end
+
+      describe "folded block" do
+        it "should output correctly" do
+          run_binary(FOLDED_BLOCK, args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"folded_style":"This entire block of text will be the value of 'folded_style', but this time, all newlines will be replaced with a single space.\\nBlank lines, like above, are converted to a newline character.\\n\\n    'More-indented' lines keep their newlines, too -\\n    this text will appear over two lines."}\n)
+          end
+        end
+      end
+    end
+
+    describe Bool do
+      it "should output correctly" do
+        run_binary(%(--- true), args: ["-i", "simpleyaml", "."]) do |output|
+          output.should eq "true\n"
+        end
+      end
+    end
+
+    describe Float do
+      it "should output correctly" do
+        run_binary(%(--- 10.50), args: ["-i", "simpleyaml", "."]) do |output|
+          output.should eq "10.5\n"
+        end
+      end
+    end
+
+    describe Nil do
+      it "should output correctly" do
+        run_binary(%(--- ), args: ["-i", "simpleyaml", "."]) do |output|
+          output.should eq "null\n"
+        end
+      end
+    end
+
+    describe Object do
+      describe "a simple object" do
+        it "should output correctly" do
+          run_binary(%(---\nname: Jim), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"name":"Jim"}\n)
+          end
+        end
+      end
+
+      describe "with spaces in the key" do
+        it "should output correctly" do
+          run_binary(%(---\nkey with spaces: value), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"key with spaces":"value"}\n)
+          end
+        end
+      end
+
+      describe "with a quoted key key" do
+        it "should output correctly" do
+          run_binary(%(---\n'Keys can be quoted too.': value), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"Keys can be quoted too.":"value"}\n)
+          end
+        end
+      end
+
+      describe "with nested object" do
+        it "should output correctly" do
+          run_binary(NESTED_OBJECT, args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"a_nested_map":{"key":"value","another_key":"Another Value","another_nested_map":{"hello":"hello"}}}\n)
+          end
+        end
+      end
+
+      describe "with a non string key" do
+        it "should output correctly" do
+          run_binary(%(---\n0.25: a float key), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"0.25":"a float key"}\n)
+          end
+        end
+      end
+
+      describe "with JSON syntax" do
+        describe "with quotes" do
+          it "should output correctly" do
+            run_binary(%(---\njson_seq: {"key": "value"}), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+              output.should eq %({"json_seq":{"key":"value"}}\n)
+            end
+          end
+        end
+
+        describe "without quotes" do
+          it "should output correctly" do
+            run_binary(%(---\njson_seq: {key: value}), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+              output.should eq %({"json_seq":{"key":"value"}}\n)
+            end
+          end
+        end
+      end
+
+      describe "with a complex mapping key" do
+        it "should output correctly" do
+          run_binary(COMPLEX_MAPPING_KEY, args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"This is a key\\nthat has multiple lines\\n":"and this is its value"}\n)
+          end
+        end
+      end
+
+      describe "with set notation" do
+        it "should output correctly" do
+          run_binary(%(---\nset:\n  ? item1\n  ? item2), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"set":{"item1":null,"item2":null}}\n)
+          end
+        end
+      end
+
+      pending "with a complex sequence key" do
+        it "should output correctly" do
+          run_binary(COMPLEX_SEQUENCE_KEY, args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"["Manchester United", "Real Madrid"]":["2001-01-01T00:00:00Z","2002-02-02T00:00:00Z"]}\n)
+          end
+        end
+      end
+    end
+
+    describe Array do
+      describe "with mixed/nested array values" do
+        it "should output correctly" do
+          run_binary(NESTED_ARRAY, args: ["-i", "simpleyaml", "-c", "."]) do |output|
+            output.should eq %({"a_sequence":["Item 1","Item 2",0.5,"Item 4",{"key":"value","another_key":"another_value"},["This is a sequence","inside another sequence"],[["Nested sequence indicators","can be collapsed"]]]}\n)
+          end
+        end
+      end
+
+      describe "with JSON syntax" do
+        describe "with quotes" do
+          it "should output correctly" do
+            run_binary(%(---\njson_seq: [3, 2, 1, "takeoff"]), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+              output.should eq %({"json_seq":[3,2,1,"takeoff"]}\n)
+            end
+          end
+        end
+
+        describe "without quotes" do
+          it "should output correctly" do
+            run_binary(%(---\njson_seq: [3, 2, 1, takeoff]), args: ["-i", "simpleyaml", "-c", "."]) do |output|
+              output.should eq %({"json_seq":[3,2,1,"takeoff"]}\n)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe ".serialize" do
+    describe String do
+      describe "not blank" do
+        it "should output correctly" do
+          run_binary(%("Jim"), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should start_with <<-YAML
+            --- Jim
+            YAML
+          end
+        end
+      end
+
+      describe "blank" do
+        it "should output correctly" do
+          run_binary(%(""), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              --- ""\n
+              YAML
+            )
+          end
+        end
+      end
+    end
+
+    describe Bool do
+      it "should output correctly" do
+        run_binary(%(true), args: ["-o", "simpleyaml", "."]) do |output|
+          output.should start_with <<-YAML
+            --- true
+            YAML
+        end
+      end
+    end
+
+    describe Float do
+      it "should output correctly" do
+        run_binary(%("1.5"), args: ["-o", "simpleyaml", "."]) do |output|
+          output.should eq(<<-YAML
+            --- "1.5"\n
+            YAML
+          )
+        end
+      end
+    end
+
+    describe Nil do
+      it "should output correctly" do
+        run_binary("null", args: ["-o", "simpleyaml", "."]) do |output|
+          output.should start_with "---"
+        end
+      end
+    end
+
+    describe Array do
+      describe "empty array on root" do
+        it "should emit a self closing root tag" do
+          run_binary("[]", args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              --- []\n
+              YAML
+            )
+          end
+        end
+      end
+
+      describe "array with values on root" do
+        it "should emit item tags for non empty values" do
+          run_binary(%(["x",{}]), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              ---
+              - x
+              - {}\n
+              YAML
+            )
+          end
+        end
+      end
+
+      describe "object with empty array/values" do
+        it "should emit self closing tags for each" do
+          run_binary(%({"a":[],"b":{},"c":null}), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should start_with <<-YAML
+              ---
+              a: []
+              b: {}
+              c:
+              YAML
+          end
+        end
+      end
+
+      describe "2D array object value" do
+        it "should emit key name tag then self closing item tag" do
+          run_binary(%({"a":[[]]}), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              ---
+              a:
+              - []\n
+              YAML
+            )
+          end
+        end
+      end
+
+      describe "object value mixed/nested array values" do
+        it "should emit correctly" do
+          run_binary(%({"x":[1,[2,[3]]]}), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              ---
+              x:
+              - 1
+              - - 2
+                - - 3\n
+              YAML
+            )
+          end
+        end
+      end
+
+      describe "object value array primitive values" do
+        it "should emit correctly" do
+          run_binary(%({"x":[1,2,3]}), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              ---
+              x:
+              - 1
+              - 2
+              - 3\n
+              YAML
+            )
+          end
+        end
+      end
+    end
+
+    describe Object do
+      describe "simple key/value" do
+        it "should output correctly" do
+          run_binary(%({"name":"Jim"}), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              ---
+              name: Jim\n
+              YAML
+            )
+          end
+        end
+      end
+
+      describe "nested object" do
+        it "should output correctly" do
+          run_binary(%({"name":"Jim", "city": {"street":"forbs"}}), args: ["-o", "simpleyaml", "."]) do |output|
+            output.should eq(<<-YAML
+              ---
+              name: Jim
+              city:
+                street: forbs\n
+              YAML
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/converters/xml_spec.cr
+++ b/spec/converters/xml_spec.cr
@@ -146,7 +146,7 @@ XML_ALL_EMPTY = <<-XML
 </root>
 XML
 
-describe OQ::Converters::Xml do
+describe OQ::Converters::XML do
   describe ".deserialize" do
     # See https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html
     describe "conventions" do

--- a/spec/converters/yaml_spec.cr
+++ b/spec/converters/yaml_spec.cr
@@ -71,7 +71,7 @@ bar: &bar
   age: 20
 YAML
 
-describe OQ::Converters::Yaml do
+describe OQ::Converters::YAML do
   describe ".deserialize" do
     describe String do
       describe "not blank" do

--- a/spec/format_spec.cr
+++ b/spec/format_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe OQ::Format do
   describe ".to_s" do
     it "returns a comma separated list of the formats" do
-      OQ::Format.to_s.should eq "json, yaml, xml"
+      OQ::Format.to_s.should eq "json, simpleyaml, xml, yaml"
     end
   end
 end

--- a/src/converters/json.cr
+++ b/src/converters/json.cr
@@ -1,4 +1,4 @@
-module OQ::Converters::Json
+module OQ::Converters::JSON
   def self.deserialize(input : IO, output : IO, **args) : Nil
     IO.copy input, output
   end

--- a/src/converters/json.cr
+++ b/src/converters/json.cr
@@ -1,3 +1,4 @@
+# Converter for the `OQ::Format::JSON` format.
 module OQ::Converters::JSON
   def self.deserialize(input : IO, output : IO, **args) : Nil
     IO.copy input, output

--- a/src/converters/simple_yaml.cr
+++ b/src/converters/simple_yaml.cr
@@ -1,0 +1,55 @@
+require "./yaml"
+
+# Converter for the `OQ::Format::SimpleYAML` format.
+module OQ::Converters::SimpleYAML
+  extend OQ::Converters::YAML
+  extend self
+
+  # ameba:disable Metrics/CyclomaticComplexity
+  def deserialize(input : IO, output : IO, **args) : Nil
+    yaml = ::YAML::PullParser.new(input)
+    json = ::JSON::Builder.new(output)
+
+    yaml.read_stream do
+      loop do
+        case yaml.kind
+        when .document_start?
+          json.start_document
+        when .document_end?
+          json.end_document
+          yaml.read_next
+          break
+        when .scalar?
+          string = yaml.value
+
+          if json.next_is_object_key?
+            json.scalar(string)
+          else
+            scalar = ::YAML::Schema::Core.parse_scalar(yaml)
+            case scalar
+            when Nil
+              json.scalar(scalar)
+            when Bool
+              json.scalar(scalar)
+            when Int64
+              json.scalar(scalar)
+            when Float64
+              json.scalar(scalar)
+            else
+              json.scalar(string)
+            end
+          end
+        when .sequence_start?
+          json.start_array
+        when .sequence_end?
+          json.end_array
+        when .mapping_start?
+          json.start_object
+        when .mapping_end?
+          json.end_object
+        end
+        yaml.read_next
+      end
+    end
+  end
+end

--- a/src/converters/xml.cr
+++ b/src/converters/xml.cr
@@ -1,13 +1,13 @@
-module OQ::Converters::Xml
+module OQ::Converters::XML
   def self.deserialize(input : IO, output : IO, **args) : Nil
-    builder = JSON::Builder.new output
-    xml = XML::Reader.new input
+    builder = ::JSON::Builder.new output
+    xml = ::XML::Reader.new input
 
     # Set reader to first element
     xml.read
 
     # Raise an error if the document is invalid and could not be read
-    raise XML::Error.new LibXML.xmlGetLastError if xml.node_type.none?
+    raise ::XML::Error.new LibXML.xmlGetLastError if xml.node_type.none?
 
     builder.document do
       builder.object do
@@ -21,7 +21,7 @@ module OQ::Converters::Xml
     end
   end
 
-  private def self.process_element_node(node : XML::Node, builder : JSON::Builder) : Nil
+  private def self.process_element_node(node : ::XML::Node, builder : ::JSON::Builder) : Nil
     # If the node doesn't have nested elements nor attributes; just emit a scalar value
     if !has_nested_elements(node) && node.attributes.empty?
       return builder.field node.name, get_node_value node
@@ -35,7 +35,7 @@ module OQ::Converters::Xml
     end
   end
 
-  private def self.process_array_node(name : String, children : Array(XML::Node), builder : JSON::Builder) : Nil
+  private def self.process_array_node(name : String, children : Array(::XML::Node), builder : ::JSON::Builder) : Nil
     builder.field name do
       builder.array do
         children.each do |node|
@@ -53,7 +53,7 @@ module OQ::Converters::Xml
     end
   end
 
-  private def self.process_children(node : XML::Node, builder : JSON::Builder) : Nil
+  private def self.process_children(node : ::XML::Node, builder : ::JSON::Builder) : Nil
     # Process node attributes
     node.attributes.each do |attr|
       builder.field "@#{attr.name}", attr.content
@@ -86,17 +86,17 @@ module OQ::Converters::Xml
     end
   end
 
-  private def self.has_nested_elements(node : XML::Node) : Bool
+  private def self.has_nested_elements(node : ::XML::Node) : Bool
     node.children.any? { |child| !child.text? && !child.cdata? }
   end
 
-  private def self.get_node_value(node : XML::Node) : String?
+  private def self.get_node_value(node : ::XML::Node) : String?
     node.children.empty? ? nil : node.children.first.content
   end
 
   def self.serialize(input : IO, output : IO, **args) : Nil
-    json = JSON::PullParser.new input
-    builder = XML::Builder.new output
+    json = ::JSON::PullParser.new input
+    builder = ::XML::Builder.new output
     indent, prolog, root, xml_item = self.parse_args(args)
 
     builder.indent = indent
@@ -123,7 +123,7 @@ module OQ::Converters::Xml
     }
   end
 
-  private def self.emit(builder : XML::Builder, json : JSON::PullParser, key : String? = nil, array_key : String? = nil, *, xml_item : String) : Nil
+  private def self.emit(builder : ::XML::Builder, json : ::JSON::PullParser, key : String? = nil, array_key : String? = nil, *, xml_item : String) : Nil
     case json.kind
     when .null?                           then json.read_null
     when .string?, .int?, .float?, .bool? then builder.text get_value json
@@ -134,7 +134,7 @@ module OQ::Converters::Xml
     end
   end
 
-  private def self.handle_object(builder : XML::Builder, json : JSON::PullParser, key : String? = nil, array_key : String? = nil, *, xml_item : String) : Nil
+  private def self.handle_object(builder : ::XML::Builder, json : ::JSON::PullParser, key : String? = nil, array_key : String? = nil, *, xml_item : String) : Nil
     json.read_object do |k|
       if k.starts_with?('@')
         builder.attribute k.lchop('@'), get_value json
@@ -152,7 +152,7 @@ module OQ::Converters::Xml
     end
   end
 
-  private def self.handle_array(builder : XML::Builder, json : JSON::PullParser, key : String? = nil, array_key : String? = nil, *, xml_item : String) : Nil
+  private def self.handle_array(builder : ::XML::Builder, json : ::JSON::PullParser, key : String? = nil, array_key : String? = nil, *, xml_item : String) : Nil
     json.read_begin_array
     array_key = array_key || xml_item
 
@@ -169,7 +169,7 @@ module OQ::Converters::Xml
     json.read_end_array
   end
 
-  private def self.get_value(json : JSON::PullParser) : String
+  private def self.get_value(json : ::JSON::PullParser) : String
     case json.kind
     when .string? then json.read_string
     when .int?    then json.read_int

--- a/src/converters/xml.cr
+++ b/src/converters/xml.cr
@@ -1,3 +1,4 @@
+# Converter for the `OQ::Format::XML` format.
 module OQ::Converters::XML
   def self.deserialize(input : IO, output : IO, **args) : Nil
     builder = ::JSON::Builder.new output

--- a/src/converters/yaml.cr
+++ b/src/converters/yaml.cr
@@ -1,13 +1,13 @@
-module OQ::Converters::Yaml
+module OQ::Converters::YAML
   # OPTIMIZE: Figure out a way to handle aliases/anchors while streaming.
   def self.deserialize(input : IO, output : IO, **args) : Nil
-    YAML.parse(input).to_json output
+    ::YAML.parse(input).to_json output
   end
 
   # ameba:disable Metrics/CyclomaticComplexity
   def self.serialize(input : IO, output : IO, **args) : Nil
-    json = JSON::PullParser.new input
-    yaml = YAML::Builder.new output
+    json = ::JSON::PullParser.new input
+    yaml = ::YAML::Builder.new output
 
     yaml.stream do
       yaml.document do
@@ -22,7 +22,7 @@ module OQ::Converters::Yaml
           when .float?
             yaml.scalar json.float_value
           when .string?
-            if YAML::Schema::Core.reserved_string? json.string_value
+            if ::YAML::Schema::Core.reserved_string? json.string_value
               yaml.scalar json.string_value, style: :double_quoted
             else
               yaml.scalar json.string_value

--- a/src/converters/yaml.cr
+++ b/src/converters/yaml.cr
@@ -1,11 +1,13 @@
+# Converter for the `OQ::Format::YAML` format.
 module OQ::Converters::YAML
-  # OPTIMIZE: Figure out a way to handle aliases/anchors while streaming.
-  def self.deserialize(input : IO, output : IO, **args) : Nil
+  extend self
+
+  def deserialize(input : IO, output : IO, **args) : Nil
     ::YAML.parse(input).to_json output
   end
 
   # ameba:disable Metrics/CyclomaticComplexity
-  def self.serialize(input : IO, output : IO, **args) : Nil
+  def serialize(input : IO, output : IO, **args) : Nil
     json = ::JSON::PullParser.new input
     yaml = ::YAML::Builder.new output
 

--- a/src/oq.cr
+++ b/src/oq.cr
@@ -10,9 +10,16 @@ module OQ
 
   # The support formats that can be converted to/from.
   enum Format
-    Json
-    Yaml
-    Xml
+    # The [JSON](https://www.json.org/) format.
+    JSON
+
+    # The [YAML](https://yaml.org/) format.
+    YAML
+
+    # The [XML](https://en.wikipedia.org/wiki/XML) format.
+    #
+    # NOTE: Conversion two and from `JSON` uses [this](https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html) spec.
+    XML
 
     # Returns the list of supported formats.
     def self.to_s(io : IO) : Nil
@@ -77,8 +84,8 @@ module OQ
     @args : Array(String) = [] of String
 
     def initialize(
-      @input_format : Format = Format::Json,
-      @output_format : Format = Format::Json,
+      @input_format : Format = Format::JSON,
+      @output_format : Format = Format::JSON,
       @xml_root : String = "root",
       @xml_prolog : Bool = true,
       @xml_item : String = "item",

--- a/src/oq.cr
+++ b/src/oq.cr
@@ -13,13 +13,17 @@ module OQ
     # The [JSON](https://www.json.org/) format.
     JSON
 
-    # The [YAML](https://yaml.org/) format.
-    YAML
+    # Same as `YAML`, but does not support [anchors or aliases](https://yaml.org/spec/1.2/spec.html#id2765878);
+    # thus allowing for the input conversion to be streamed, reducing the memory usage for large inputs.
+    SimpleYAML
 
     # The [XML](https://en.wikipedia.org/wiki/XML) format.
     #
     # NOTE: Conversion two and from `JSON` uses [this](https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html) spec.
     XML
+
+    # The [YAML](https://yaml.org/) format.
+    YAML
 
     # Returns the list of supported formats.
     def self.to_s(io : IO) : Nil
@@ -31,7 +35,7 @@ module OQ
       {% begin %}
         case self
           {% for format in @type.constants %}
-            in .{{format.downcase.id}}? then OQ::Converters::{{format.id}}
+            in .{{format.underscore.downcase.id}}? then OQ::Converters::{{format.id}}
           {% end %}
         end
       {% end %}


### PR DESCRIPTION
Resolves #68

* Add the `SimpleYAML` input format
  * Similar to `YAML` input format, but without alias/anchor support to allow streaming the input conversion.  E.g. to save memory on large inputs.
* Improve format docs & fix format/converter casing