### PR TITLE
Properly handle prefixed scalar value elements

### DIFF
--- a/spec/converters/xml_spec.cr
+++ b/spec/converters/xml_spec.cr
@@ -321,27 +321,27 @@ describe OQ::Converters::XML do
       end
 
       describe "with namespaces" do
-        it "strips prefixes and namespace declarations of a prefixed namespace" do
+        it "retains prefixes but strips namespace declarations of a prefixed namespace" do
           run_binary(%(<?xml version="1.0"?><a:foo xmlns:a="http://www.w3.org/1999/xhtml">bar</a:foo>), args: ["-i", "xml", "-c", "."]) do |output|
-            output.should eq %({"foo":"bar"}\n)
+            output.should eq %({"a:foo":"bar"}\n)
           end
         end
 
-        it "strips prefixes and namespace declarations of a multiple namespaces" do
+        it "does not add pefix if none was already present but strips namespace declarations" do
           run_binary(%(<?xml version="1.0"?><foo xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:a="http://www.w3.org/1999/xhtml">bar</foo>), args: ["-i", "xml", "-c", "."]) do |output|
             output.should eq %({"foo":"bar"}\n)
           end
         end
 
-        it "skips prefixed elements that cause mixed content" do
+        it "treats prefixed & unprefixed elements as unique elements" do
           run_binary(XML_NESTED_NAMESPACES, args: ["-i", "xml", "-c", "."]) do |output|
-            output.should eq %({"root":{"foo":{"bar":{"baz":null}}}}\n)
+            output.should eq %({"root":{"a:foo":"herp","foo":{"bar":{"baz":null}}}}\n)
           end
         end
 
-        it "strips prefixes of elements" do
+        it "retains prefixes of scalar value elements" do
           run_binary(XML_NAMESPACE_PREFIXES, args: ["-i", "xml", "-c", "."]) do |output|
-            output.should eq %({"root":{"foo":"foo","bar":"bar"}}\n)
+            output.should eq %({"root":{"foo":"foo","a:bar":"bar"}}\n)
           end
         end
       end
@@ -399,7 +399,7 @@ describe OQ::Converters::XML do
       end
 
       describe "with namespaces" do
-        it "strips prefixes and namespace declarations" do
+        it "treats prefixed & unprefixed elements as unique elements" do
           run_binary(XML_NAMESPACE_ARRAY, args: ["-i", "xml", "-c", "."]) do |output|
             output.should eq %({"items":{"n:number":["1","2"],"number":"3"}}\n)
           end

--- a/src/converters/xml.cr
+++ b/src/converters/xml.cr
@@ -25,7 +25,7 @@ module OQ::Converters::XML
   private def self.process_element_node(node : ::XML::Node, builder : ::JSON::Builder) : Nil
     # If the node doesn't have nested elements nor attributes; just emit a scalar value
     if !has_nested_elements(node) && node.attributes.empty?
-      return builder.field node.name, get_node_value node
+      return builder.field self.normalize_node_name(node), get_node_value node
     end
 
     # Otherwise process the node as a key/value pair


### PR DESCRIPTION
Follow up to #88.  Realized that the fact prefixes were getting stripped was a bug.  This PR fixes that for scalar value elements.  