### PR TITLE
Additional XML improvements

### DIFF
--- a/src/converters/xml.cr
+++ b/src/converters/xml.cr
@@ -99,7 +99,7 @@ module OQ::Converters::XML
       end
 
       # Array
-      if children.size > 1
+      if children.size > 1 || self.processor.xml_forced_arrays.includes? name
         process_array_node name, children, builder
       else
         if children.first.text?

--- a/src/oq.cr
+++ b/src/oq.cr
@@ -90,8 +90,14 @@ module OQ
     # Mapping to namespace aliases to their related namespace.
     protected getter xml_namespaces = Hash(String, String).new
 
+    # Set of elements who should be force expanded to an array.
+    protected getter xml_forced_arrays = Set(String).new
+
     # The args that'll be passed to `jq`.
     @args : Array(String) = [] of String
+
+    # Keep a reference to the created temp files in order to delete them later.
+    @tmp_files = Set(File).new
 
     def initialize(
       @input_format : Format = Format::JSON,
@@ -124,8 +130,9 @@ module OQ
       @xml_namespaces[href] = prefix
     end
 
-    # Keep a reference to the created temp files in order to delete them later.
-    @tmp_files = Set(File).new
+    def add_forced_array(name : String) : Nil
+      xml_forced_arrays << name
+    end
 
     # Consumes `#input_format` data from the provided *input* `IO`, along with any *input_args*.
     # The data is then converted to `JSON`, passed to `jq`, and then converted to `#output_format` while being written to the *output* `IO`.
@@ -146,9 +153,9 @@ module OQ
       # Extract `jq` arguments from `ARGV`.
       self.extract_args input_args, output
 
-      # The --namespace-alias option must be used with the --xmlns option.
+      # The --xml-namespace-alias option must be used with the --xmlns option.
       # TODO: Remove this in oq 2.x
-      raise ArgumentError.new "The `--namespace-alias` option must be used with the `--xmlns` option." if !@xmlns && !@xml_namespaces.empty?
+      raise ArgumentError.new "The `--xml-namespace-alias` option must be used with the `--xmlns` option." if !@xmlns && !@xml_namespaces.empty?
 
       # Replace the *input* with a fake `ARGF` `IO` to handle both file and `IO` inputs
       # in case `ARGV` is not being used for the input arguments.

--- a/src/oq_cli.cr
+++ b/src/oq_cli.cr
@@ -31,7 +31,8 @@ OptionParser.parse do |parser|
   parser.on("--no-prolog", "Whether the XML prolog should be emitted if converting to XML.") { processor.xml_prolog = false }
   parser.on("--xml-item NAME", "The name for XML array elements without keys.") { |i| processor.xml_item = i }
   parser.on("--xmlns", "If XML namespaces should be parsed.  NOTE: This will become the default in oq 2.x.") { processor.xmlns = true }
-  parser.on("--namespace-alias NS", "Value should be in the form of: `key=namespace`. Elements within the provided namespace are normalized to the provided key.  NOTE: Requires the `--xmlns` option to be passed as well.") { |ns| k, v = ns.split('=', 2); processor.add_xml_namespace k, v }
+  parser.on("--xml-force-array NAME", "Forces an element with the provided name to be parsed as an array even if it only contains one item.") { |n| processor.add_forced_array n }
+  parser.on("--xml-namespace-alias ALIAS", "Value should be in the form of: `key=namespace`. Elements within the provided namespace are normalized to the provided key.  NOTE: Requires the `--xmlns` option to be passed as well.") { |a| k, v = a.split('=', 2); processor.add_xml_namespace k, v }
   parser.on("--xml-root ROOT", "Name of the root XML element if converting to XML.") { |r| processor.xml_root = r }
   parser.invalid_option { }
 end


### PR DESCRIPTION
* Add ability to force an element to be parsed as an array
* Rename XML alias CLI option

\cc @LoganBarnett, I renamed the option introduced in #89 to make it more consistent with the other XML only options.