### PR TITLE
Explicitly set git author to use for the Homebrew PR

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,6 +41,8 @@ jobs:
   dist_homebrew:
     runs-on: macos-latest
     steps:
+      - run: git config --global user.email "george@dietrich.app"
+      - run: git config --global user.name "George Dietrich"
       - name: Bump Formula
         uses: Homebrew/actions/bump-formulae@670c072417822feda3a55718b43b41fbd49de9bb
         with:


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/83453 was created with `runner` as the author.  This PR sets the author so it's tied to an actual user.