### PR TITLE
Update build/deploy scripts

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -5,6 +5,11 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   dist_linux:
     runs-on: ubuntu-latest
@@ -34,8 +39,9 @@ jobs:
         id: build
       - name: Publish Snap
         uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          store_login: ${{ secrets.STORE_LOGIN }}
           snap: ${{ steps.build.outputs.snap }}
           release: stable
   dist_homebrew:
@@ -49,16 +55,22 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           formulae: oq
   deploy_docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Build
         run: crystal docs
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          branch: gh-pages
-          folder: docs
-          single-commit: true
+          path: 'docs/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,11 +7,13 @@ description: |
 contact: george@dietrich.app
 issues: https://github.com/Blacksmoke16/oq/issues
 website: https://github.com/Blacksmoke16/oq
+source-code: https://github.com/Blacksmoke16/oq.git
 license: MIT
 
 grade: stable
 confinement: strict
-base: core18
+base: core20
+type: app
 
 apps:
   oq:
@@ -30,3 +32,6 @@ parts:
     source: ./
     stage-packages:
       - jq
+    override-pull: |
+      snapcraftctl pull
+      rm -rf $SNAPCRAFT_PART_SRC/lib $SNAPCRAFT_PART_SRC/bin


### PR DESCRIPTION
* Update snap to `base20`
  * Improves snap metadata
  * Works around snap crystal plugin bug
* Leverage built in GHA for docs deployments