### PR TITLE
[release] Including arm64/aarch6 binaries in releases

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: binary-artifacts
-        path: bin/
+        path: bin/oq-*
         retention-days: 1
         if-no-files-found: error
   dist_linux_upload:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,52 +3,84 @@ name: Deployment
 on:
   release:
     types:
-      - created
+    - created
+
+env:
+  TARGET_ARCH_LIST: '["arm64","amd64"]'
 
 jobs:
-  dist_linux:
+  dist_linux_build:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:latest-alpine
+    outputs:
+      assets: ${{ steps.record_output.outputs.assets }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Update Libs
-      run: apk add --update --upgrade --no-cache --force-overwrite libxml2-dev yaml-dev yaml-static
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build
-      run: shards build --production --release --static --no-debug --link-flags="-s -Wl,-z,relro,-z,now"
+      run: ./hack/dist/build.sh
+    - name: Record output
+      id: record_output
+      run: |
+        assets="$(ls --color=no ./bin/ | jq -R -s -c 'split("\n")[:-1]')"
+        echo "assets=${assets}" | tee -a "${GITHUB_OUTPUT}"
+    - name: Upload binary artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: binary-artifacts
+        path: bin/
+        retention-days: 1
+        if-no-files-found: error
+  dist_linux_upload:
+    runs-on: ubuntu-latest
+    needs: dist_linux_build
+    strategy:
+      matrix:
+        asset: ${{ fromJSON(needs.dist_linux_build.outputs.assets) }}
+    steps:
+    - name: Download binary artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: binary-artifacts
+        path: bin
     - name: Upload
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./bin/oq
-        asset_name: oq-${{ github.event.release.tag_name }}-linux-x86_64
+        asset_path: "bin/${{ matrix.asset }}"
+        asset_name: ${{ matrix.asset }}
         asset_content_type: binary/octet-stream
   dist_snap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Build Snap
-        uses: snapcore/action-build@v1
-        id: build
-      - name: Publish Snap
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: ${{ steps.build.outputs.snap }}
-          release: stable
+    - uses: actions/checkout@v4
+    - name: Build Snap
+      uses: snapcore/action-build@v1
+      id: build
+    - name: Publish Snap
+      uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: stable
   dist_homebrew:
     runs-on: macos-latest
     steps:
-      - run: git config --global user.email "george@dietrich.app"
-      - run: git config --global user.name "George Dietrich"
-      - name: Bump Formula
-        uses: Homebrew/actions/bump-formulae@b5d9170bc1edf1103e40226592b5842b783dd1e0
-        with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          formulae: oq
+    - run: git config --global user.email "george@dietrich.app"
+    - run: git config --global user.name "George Dietrich"
+    - name: Bump Formula
+      uses: Homebrew/actions/bump-formulae@b5d9170bc1edf1103e40226592b5842b783dd1e0
+      with:
+        token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+        formulae: oq
   deploy_docs:
     environment:
       name: github-pages
@@ -59,17 +91,17 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
-      - name: Build
-        run: crystal docs
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'docs/'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    - uses: actions/checkout@v4
+    - name: Install Crystal
+      uses: crystal-lang/install-crystal@v1
+    - name: Build
+      run: crystal docs
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: 'docs/'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/hack/dist/build.sh
+++ b/hack/dist/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DOCKER_BUILDKIT=1
+export BUILDKIT_PROGRESS=plain
+
+: ${TARGET_ARCH_LIST:='["arm64","amd64"]'}
+export TARGET_ARCH_LIST=( $(jq -r .[] <<< ${TARGET_ARCH_LIST}) )
+
+if [[ "${GITHUB_ACTIONS:-"false"}" == "true" ]]; then
+  GA_GROUP_BEGIN="::group::"
+  GA_GROUP_END="::endgroup::"
+else
+  GA_GROUP_BEGIN="## "
+fi
+
+echo >&2 "## TARGET_ARCH_LIST: ${TARGET_ARCH_LIST[@]}"
+
+for arch in ${TARGET_ARCH_LIST[@]}; do
+  echo "${GA_GROUP_BEGIN}building for linux/${arch}"
+  docker build \
+    --platform linux/${arch} \
+    -t oq:${arch} \
+    -f hack/dist/dist.Dockerfile \
+    .
+  echo "${GA_GROUP_END:-}"
+done
+
+[[ -d ./bin ]] || mkdir ./bin
+
+for arch in ${TARGET_ARCH_LIST[@]}; do
+  echo "${GA_GROUP_BEGIN}retrieving oq binary for linux/${arch}"
+  docker run \
+    --platform linux/${arch} \
+    --rm \
+    --user root \
+    --entrypoint /bin/sh \
+    --volume ${PWD}/bin:/mnt/repo/bin \
+    --workdir /mnt/repo \
+    oq:${arch} \
+    -c 'cp -v "$(realpath $(which oq))" ./bin/'
+    echo "${GA_GROUP_END:-}"
+done
+
+echo "${GA_GROUP_BEGIN}listing content of ./bin"
+ls -la ./bin
+echo "${GA_GROUP_END:-}"

--- a/hack/dist/dist.Dockerfile
+++ b/hack/dist/dist.Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.4
+# NOTE: build root is the root of the repo
+
+ARG BUILD_IMAGE_BASE="alpine:3.20"
+ARG JQ_VERSION="1.7.1"
+ARG OQ_BIN_DIR="/opt/oq/bin"
+ARG OQ_BIN_USE_TARGETARCH="false"
+
+FROM ${BUILD_IMAGE_BASE} as build-base
+RUN apk add \
+      --update \
+      --upgrade \
+      --no-cache \
+      --force-overwrite \
+      crystal shards \
+      git bash curl jq \
+      libxml2-dev libxml2-static yaml-dev yaml-static xz-static zlib-static
+
+FROM build-base as build
+ARG JQ_VERSION OQ_BIN_DIR OQ_BIN_USE_TARGETARCH TARGETARCH
+WORKDIR /src
+SHELL ["/bin/bash", "-uo", "pipefail", "-c"]
+RUN --mount=type=bind,source=.,target=/src,rw <<-SCRIPT
+    #!/usr/bin/env bash
+    mkdir -p "${OQ_BIN_DIR}"
+    echo >&2 "## downloading jq"
+    JQ_REPO="jqlang/jq"
+    if [[ -z "${JQ_VERSION:-}" ]] || [[ "${JQ_VERSION}" == "latest" ]]; then
+      JQ_VERSION="$(curl -sSLq "https://api.github.com/repos/${JQ_REPO}/releases/latest" | jq -r .tag_name)"
+    fi
+    echo "### JQ_VERSION: ${JQ_VERSION}"
+    wget -qO "${OQ_BIN_DIR}/jq" \
+      "https://github.com/${JQ_REPO}/releases/download/jq-${JQ_VERSION}/jq-linux-${TARGETARCH}"
+    chmod +x "${OQ_BIN_DIR}/jq"
+    "${OQ_BIN_DIR}/jq" --version || exit 1
+    echo >&2 "## resolving OQ version"
+    OQ_VERSION="$(git describe --exact-match --tags HEAD 2>/dev/null)"
+    if [[ $? -eq 0 ]]; then
+      echo >&2 "### the HEAD is tagged"
+    else
+      echo >&2 "### the HEAD is not tagged"
+      OQ_VERSION="$(git rev-parse --short=8 HEAD)"
+      if [[ $? -ne 0 ]]; then
+        echo >&2 "### failed to get the SHA of the HEAD"
+        exit 1
+      fi
+    fi
+    if ! git diff --quiet; then
+      OQ_VERSION+="-dirty"
+    fi
+    if [[ "${OQ_BIN_USE_TARGETARCH}" == "true" ]]; then
+      echo >&2 "## using TARGETARCH in oq binary name"
+      OQ_BIN="${OQ_BIN_DIR}/oq-${OQ_VERSION}-linux-${TARGETARCH}"
+    else
+      OQ_BIN="${OQ_BIN_DIR}/oq-${OQ_VERSION}-linux-$(uname -m)"
+    fi
+    echo >&2 "## building oq ${OQ_VERSION} for linux/${TARGETARCH}"
+    shards build \
+      --production \
+      --release \
+      --static \
+      --no-debug \
+      --link-flags="-s -Wl,-z,relro,-z,now"
+    mv ./bin/oq ${OQ_BIN}
+    ln -s ${OQ_BIN} /usr/local/bin/oq
+    echo >&2 "## verifying OQ binary and checking version"
+    oq --version
+SCRIPT
+
+FROM busybox:stable-musl as release
+ARG OQ_BIN_DIR
+COPY --link --from=build ${OQ_BIN_DIR}/* /usr/local/bin/
+RUN cd /usr/local/bin && find . -type f -executable -name "oq*" -exec ln -s {} oq \;
+USER nobody
+ENTRYPOINT ["oq"]

--- a/hack/dist/dist.Dockerfile.dockerignore
+++ b/hack/dist/dist.Dockerfile.dockerignore
@@ -1,0 +1,3 @@
+.github/workflows/
+bin/
+hack/


### PR DESCRIPTION
It would be nice to release both amd64 and arm64 versions of binaries.. Being able to download a statically compiled binary of `oq` directly from the project's Github releases would allow not having to rely on distro's package manager, or having to compile it from scratch, when specific version is required. Moving the binary build process into docker image build can help with that, along with the benefit of having a publishable `oq` docker image.

* adding Dockerfile to build `oq` binaries, along with the build script
* updating GA workflow to build both arm64 and amd64 release binaries
  + updating workflow indentation for consistency
  + separating the binary build and upload steps into separate jobs
  + adding the use of `upload-artifact` and `download-artifact` actions to deliver binaries across jobs
  + using matrix strategy on `upload-release-asset` step to push all binaries built

TODO: update to support using desired crystal-lang version